### PR TITLE
chore: Update invalid crate category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.2"
 authors = ["Agustin Borgna <agustinborgna@gmail.com>"]
 description = "New Type idiom helper for string-like types"
 keywords = ["newtype", "string", "wrapper"]
-categories = ["strings"]
+categories = ["data-structures"]
 
 rust-version = "1.68"
 edition = "2021"


### PR DESCRIPTION
Update'd the package category to one of the [allowed slugs](https://crates.io/category_slugs).